### PR TITLE
support non-kcp environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go $(NAME_PREFIX)$(APIEXPORT_NAME)
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: build ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push
@@ -100,6 +100,11 @@ install: manifests kustomize ## Install APIResourceSchemas and APIExport into kc
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall APIResourceSchemas and APIExport from kcp (using $KUBECONFIG or ~/.kube/config). Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	kustomize build config/kcp | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: deploy-crd
+deploy-crd: manifests kustomize ## Deploy controller
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default-crd | kubectl apply -f - || true
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller

--- a/config/default-crd/kustomization.yaml
+++ b/config/default-crd/kustomization.yaml
@@ -1,0 +1,74 @@
+# Adds namespace to all resources.
+namespace: controller-runtime-example-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: controller-runtime-example-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patchesStrategicMerge:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+- manager_auth_proxy_patch.yaml
+
+# Mount the controller config file for loading manager configurations
+# through a ComponentConfig type
+#- manager_config_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/config/default-crd/manager_auth_proxy_patch.yaml
+++ b/config/default-crd/manager_auth_proxy_patch.yaml
@@ -1,0 +1,34 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/config/default-crd/manager_config_patch.yaml
+++ b/config/default-crd/manager_config_patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--config=controller_manager_config.yaml"
+        volumeMounts:
+        - name: manager-config
+          mountPath: /controller_manager_config.yaml
+          subPath: controller_manager_config.yaml
+      volumes:
+      - name: manager-config
+        configMap:
+          name: manager-config

--- a/config/kcp/clusterrole.yaml
+++ b/config/kcp/clusterrole.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kcp-manager-role
+rules:
+- apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports/content
+  verbs:
+  - '*'

--- a/config/kcp/clusterrolebinding.yaml
+++ b/config/kcp/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kcp-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kcp-manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
   - today.apiresourceschemas.yaml
   - apiexport.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
 
 configurations:
   - kustomizeconfig.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
       - command:
         - /manager
         args:
-        - data.my.domain
+        - --api-export-name data.my.domain
         - --leader-elect
         image: controller:latest
         name: manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,98 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports/status
+  verbs:
+  - get
+- apiGroups:
   - data.my.domain
   resources:
   - widgets

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kcp-dev/controller-runtime-example
 go 1.17
 
 require (
-	github.com/kcp-dev/apimachinery v0.0.0-20220621200107-3d03cbbc3770
+	github.com/kcp-dev/apimachinery v0.0.0-20220627134323-8c44889e6e09
 	github.com/kcp-dev/kcp/pkg/apis v0.5.0-alpha.1
 	github.com/kcp-dev/logicalcluster v1.0.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,9 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kcp-dev/apimachinery v0.0.0-20220621200107-3d03cbbc3770 h1:vO2xIamfv7laTXwf8x+WZKugB1JTF62gHZgf+D0OY9E=
 github.com/kcp-dev/apimachinery v0.0.0-20220621200107-3d03cbbc3770/go.mod h1:FIzhTU6DM3HYZhGv8w/1S/mbmSv1HzulZpjr/1/6i/I=
+github.com/kcp-dev/apimachinery v0.0.0-20220627134323-8c44889e6e09 h1:glJkPAb39Ca6UjSQzN3IEQUhSwqMsQ1CyqDYIJEo7V0=
+github.com/kcp-dev/apimachinery v0.0.0-20220627134323-8c44889e6e09/go.mod h1:FIzhTU6DM3HYZhGv8w/1S/mbmSv1HzulZpjr/1/6i/I=
 github.com/kcp-dev/controller-runtime v0.11.3-0.20220624161137-f6e5a2f56683 h1:eev0JOSMdDsRfiTmmRPaYrTUXM/sTq+j2/4oNx78zFQ=
 github.com/kcp-dev/controller-runtime v0.11.3-0.20220624161137-f6e5a2f56683/go.mod h1:XP0cED2MCy2/reuXqTwLEENUkZlu6GE1UbQx55IUyA4=
 github.com/kcp-dev/kcp/pkg/apis v0.5.0-alpha.1 h1:Z8L4TOam02khARPvS0d3kdyFB1yfwYTCx9x+i09KRzY=


### PR DESCRIPTION
This improves the code to support also non-kcp environment.

it depends on: 
* https://github.com/kcp-dev/apimachinery/pull/35
* https://github.com/kcp-dev/controller-runtime/pull/14

the changes introduced in this PR:
* adds a new overlay called `default-crd` that includes the CRDs into the manifests to be deployed
* adds new makefile target `deploy-crd` to deploy that `default-crd` overlay
* adds ClusterRole(Binding) granting permissions to get/list `APIExport` and its content
* adds kubebuilder markers to get necessary permissions for `namespaces`, `secrets`, and `configmaps`
* modifies the `ConfigMapReconciler` so it doesn't list all `configmaps` if it runs in a normal cluster
* modifies the `main.go` so it:
    * checks if the `apis.kcp.dev group` is present - if not, then it creates the manager using standard cache & client
    * takes the APIExport from a flag `--api-export-name`
    * if APIExport name is not set, then it lists all APIExports and takes the one that is found
    * fixes leader election so it uses the original RestConfig (not the one of the VirtualWorkspace)
 
fixes: https://github.com/kcp-dev/apimachinery/issues/32
   