### PR TITLE
Fix issue with missing "--api-export-name="

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -72,6 +72,10 @@ vars:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+- name: API_EXPORT_NAME
+  objref:
+    apiVersion: apis.kcp.dev/v1alpha1
+    kind: APIExport
+    name: data.my.domain
+  fieldref:
+    fieldPath: metadata.name

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,5 +1,0 @@
-nameReference:
-- kind: APIExport
-  fieldSpecs:
-    - kind: Deployment
-      path: spec/template/spec/containers/args

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -29,7 +29,7 @@ spec:
             memory: 64Mi
       - name: manager
         args:
-        - data.my.domain
+        - "--api-export-name=$(API_EXPORT_NAME)"
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
       - command:
         - /manager
         args:
-        - --api-export-name data.my.domain
+        - --api-export-name=data.my.domain
         - --leader-elect
         image: controller:latest
         name: manager


### PR DESCRIPTION
After kustomize is run the flag passed as an arg in deployment is missing "--api-export-name=" and only contains the value.
This leads to the following error if multiple APIExport are in the workspace:
~~~
I0715 15:34:48.742886       1 round_trippers.go:553] GET https://192.168.0.149:6443/apis/apis.kcp.dev/v1alpha1/apiexports 200 OK in 1 milliseconds
1.6578992887432044e+09	ERROR	setup	error looking up virtual workspace URL	{"api-export-name": "", "error": "more than one APIExport found"}
runtime.main
	/usr/local/go/src/runtime/proc.go:255
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x137210a]
~~~

This PR fixes the issue by using a variable instead of a nameReference, which does not contain  "--api-export-name="  but only the value.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>