### PR TITLE
upgrade logicalcluster to fix missing WithCluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/kcp-dev/controller-runtime-example
 go 1.17
 
 require (
-	github.com/kcp-dev/apimachinery v0.0.0-20220627134323-8c44889e6e09
 	github.com/kcp-dev/kcp/pkg/apis v0.5.0-alpha.1
-	github.com/kcp-dev/logicalcluster v1.0.0
+	github.com/kcp-dev/logicalcluster v1.1.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	k8s.io/api v0.23.5
@@ -40,6 +39,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kcp-dev/apimachinery v0.0.0-20220627134323-8c44889e6e09 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,9 @@ github.com/kcp-dev/controller-runtime v0.11.3-0.20220624161137-f6e5a2f56683 h1:e
 github.com/kcp-dev/controller-runtime v0.11.3-0.20220624161137-f6e5a2f56683/go.mod h1:XP0cED2MCy2/reuXqTwLEENUkZlu6GE1UbQx55IUyA4=
 github.com/kcp-dev/kcp/pkg/apis v0.5.0-alpha.1 h1:Z8L4TOam02khARPvS0d3kdyFB1yfwYTCx9x+i09KRzY=
 github.com/kcp-dev/kcp/pkg/apis v0.5.0-alpha.1/go.mod h1:7MSnXcgGi9YpzeA0/ebqTkQka3KyfgYKfxD+e9z9GP4=
-github.com/kcp-dev/logicalcluster v1.0.0 h1:qCnoUNaqJ0Tgefkj3vXn17EC76AP44WZwnIuHLw6yGQ=
 github.com/kcp-dev/logicalcluster v1.0.0/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
+github.com/kcp-dev/logicalcluster v1.1.1 h1:6jv54KRHDVvsJjuaV6dWNHVivYCSxDjGjfN+m1pVu3k=
+github.com/kcp-dev/logicalcluster v1.1.1/go.mod h1:3IvnQ1TDaTuyhgRqagtKWd1XKz3kBeP8ByLvyNiWywg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
Currently, without this fix:
```
% make docker-build docker-push IMG=xxx
/Users/rbobbitt/work/projects/controller-runtime-example/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
# github.com/kcp-dev/controller-runtime-example/controllers
controllers/configmap_controller.go:56:23: undefined: logicalcluster.WithCluster
controllers/widget_controller.go:59:23: undefined: logicalcluster.WithCluster
# github.com/kcp-dev/controller-runtime-example/controllers
vet: controllers/configmap_controller.go:56:23: WithCluster not declared by package logicalcluster
make: *** [vet] Error 2
```
Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>