### PR TITLE
Add namespace to the apiexport

### DIFF
--- a/config/kcp/apiexport.yaml
+++ b/config/kcp/apiexport.yaml
@@ -10,3 +10,5 @@ spec:
       resource: "secrets"
     - group: ""
       resource: "configmaps"
+    - group: ""
+      resource: "namespaces"


### PR DESCRIPTION
It is used in the configmap_controller.go

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>