### PR TITLE
Add an example of an APIBinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ make install
 ```sh
 make run
 ```
+3. Create an APIBinding to the APIExport, which was created during step 1. An example is available at [./config/kcp/apibinding.yaml](./config/kcp/apibinding.yaml)
 
 **NOTE:** You can also run this in one step by running: `make install run`
 

--- a/config/kcp/apibinding.yaml
+++ b/config/kcp/apibinding.yaml
@@ -1,0 +1,22 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+# mind that the apibinding schema has changed between kcp v0.7 and v0.8
+# this is an example for v0.8
+metadata:
+  name: controller-runtime-example-data.my.domain
+spec:
+  reference:
+    workspace:
+      exportName: data.my.domain
+      # the path needs to match the workspace where the apiexport has been created
+      path: root:organisation:apiexport-ws
+  permissionClaims:
+  - group: ""
+    resource: "secrets"
+    state: Accepted
+  - group: ""
+    resource: "configmaps"
+    state: Accepted
+  - group: ""
+    resource: "namespaces"
+    state: Accepted

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
       - command:
         - /manager
         args:
-        - --api-export-name=data.my.domain
+        - --api-export-name=controller-runtime-example-data.my.domain
         - --leader-elect
         image: controller:latest
         name: manager


### PR DESCRIPTION
It may be helpful to make the reader aware that an APIBinding needs to be created to consume the API provided by the example. 
This PR adds a sentence about it in the readme and an example.
The name of the APIExport in the deployment is aligned with what is created by `make deploy`.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>