### PR TITLE
Add CRD init to kustomize

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,6 +13,7 @@ namePrefix: controller-runtime-example-
 #  someName: someValue
 
 bases:
+- ../crd
 - ../kcp
 - ../rbac
 - ../manager


### PR DESCRIPTION
The CRD `wedget` do not create after deployment, will raise 404 in log of controller