### PR TITLE
Disable leader election, too much noise in log

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - /manager
         args:
         - --api-export-name=data.my.domain
-        - --leader-elect
+        - --leader-elect=false
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
The interval is 2 sec, too much noise in the log of controller, and there is only one replicate, no need for leader election
```
I0923 04:20:33.632567       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 19 milliseconds
I0923 04:20:33.632990       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
I0923 04:20:35.658947       1 round_trippers.go:553] GET https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 24 milliseconds
I0923 04:20:35.671078       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 11 milliseconds
I0923 04:20:35.671417       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
I0923 04:20:37.686726       1 round_trippers.go:553] GET https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 14 milliseconds
I0923 04:20:37.702415       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 15 milliseconds
I0923 04:20:37.702734       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
I0923 04:20:39.713474       1 round_trippers.go:553] GET https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 10 milliseconds
I0923 04:20:39.729839       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 13 milliseconds
I0923 04:20:39.730254       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
I0923 04:20:41.754042       1 round_trippers.go:553] GET https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 22 milliseconds
I0923 04:20:41.785280       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 30 milliseconds
I0923 04:20:41.785645       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
I0923 04:20:43.801143       1 round_trippers.go:553] GET https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 14 milliseconds
I0923 04:20:43.810940       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 9 milliseconds
I0923 04:20:43.811259       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
I0923 04:20:45.832623       1 round_trippers.go:553] GET https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 20 milliseconds
I0923 04:20:45.844730       1 round_trippers.go:553] PUT https://172.16.251.127:6443/apis/coordination.k8s.io/v1/namespaces/controller-runtime-example-system/leases/68a0532d.my.domain 200 OK in 11 milliseconds
I0923 04:20:45.845134       1 leaderelection.go:278] successfully renewed lease controller-runtime-example-system/68a0532d.my.domain
```