### PR TITLE
Add KCP APIs to scheme, enforce kind image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ kind-image: docker-build ## Load the controller-manager image into the kind clus
 	kind load docker-image $(REGISTRY)/$(IMG) --name controller-runtime-example
 
 $(ARTIFACT_DIR)/kind.kubeconfig: $(ARTIFACT_DIR) ## Run a kind cluster and generate a $KUBECONFIG for it.
-	@if ! kind get clusters --quiet | grep --quiet controller-runtime-example; then kind create cluster --name controller-runtime-example; fi
+	@if ! kind get clusters --quiet | grep --quiet controller-runtime-example; then kind create cluster --name controller-runtime-example --image kindest/node:v1.24.2; fi
 	kind get kubeconfig --name controller-runtime-example > $(ARTIFACT_DIR)/kind.kubeconfig
 
 $(ARTIFACT_DIR): ## Create a directory for test artifacts.
@@ -211,7 +211,7 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
-KUBECONFIG ?= $(abspath ~/.kube/config )
+KUBECONFIG ?= $(abspath ${HOME}/.kube/config )
 
 .PHONY: install
 install: manifests $(KUSTOMIZE) ## Install APIResourceSchemas and APIExport into kcp (using $KUBECONFIG or ~/.kube/config).

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apisv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(datav1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 


### PR DESCRIPTION
While testing out the `controller-runtime-example` Makefile, specifically running `make test-e2e` I noticed that the build was failing locally and the controller pod was crashing.

After a bit of debugging, it seems that the scheme was missing KCP's APIExport Kind, which caused the `error looking up virtual workspace URL` error, and then the panic for the controller.

In addition, this PR enforces a known working version of Kubernetes when testing locally, and it fixes an issue on Mac where the ~ sign (i.e. HOME) wasn't working properly.

Signed-off-by: Vince Prignano <vince@prigna.com>